### PR TITLE
[ci] sync template files

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
   "changelog": [
     "@changesets/changelog-github",
-    { "repo": "trueberryless-org/trueberyless" }
+    { "repo": "trueberryless-org/trueberryless" }
   ],
   "commit": false,
   "fixed": [],

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "trueberryless-monorepo",
-  "homepage": "https://github.com/trueberryless-org/trueberyless",
+  "homepage": "https://github.com/trueberryless-org/trueberryless",
   "bugs": {
-    "url": "https://github.com/trueberryless-org/trueberyless/issues"
+    "url": "https://github.com/trueberryless-org/trueberryless/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/trueberryless-org/trueberyless.git"
+    "url": "https://github.com/trueberryless-org/trueberryless.git"
   },
   "license": "MIT",
   "author": "trueberryless <trueberryless@gmail.com> (https://trueberryless.org)",


### PR DESCRIPTION
This PR syncs the specified GitHub template files from the [central repository](https://github.com/trueberryless-org/template-files).

### Changes:
- fix typo - ([d5115bb](https://github.com/trueberryless-org/template-files/commit/d5115bbea4efb1e732228a64f3a2d7cf1bddd40e))